### PR TITLE
allow custom format for returned array

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,15 +19,9 @@ module.exports = function (keyword, opts, cb) {
 	}
 
 	cb = typeof opts === 'function' ? opts : cb;
-	opts = objectAssign({description: true}, opts);
-
-	got(getUrl(keyword, opts.description), function (err, data) {
-		if (err) {
-			cb(err);
-			return;
-		}
-
-		cb(null, JSON.parse(data).rows.map(function (el) {
+	opts = objectAssign({
+		description: true,
+		format: function (el) {
 			var row = {name: el.key[1]};
 
 			if (el.key[2]) {
@@ -35,6 +29,15 @@ module.exports = function (keyword, opts, cb) {
 			}
 
 			return row;
-		}));
+		}
+	}, opts);
+
+	got(getUrl(keyword, opts.description), function (err, data) {
+		if (err) {
+			cb(err);
+			return;
+		}
+
+		cb(null, JSON.parse(data).rows.map(opts.format));
 	});
 };

--- a/test.js
+++ b/test.js
@@ -39,3 +39,17 @@ test('defaults to including description', function (t) {
 		t.assert(packages[0].description.length > 0);
 	});
 });
+
+test('uses custom formatter', function (t) {
+	t.plan(3);
+
+	var format = function (el) {
+		return el.key[1];
+	};
+
+	npmKeyword('gulpplugin', {format: format}, function (err, packages) {
+		t.assert(!err, err);
+		t.assert(Array.isArray(packages));
+		t.assert(typeof packages[0] === 'string');
+	});
+});


### PR DESCRIPTION
Allows the returned array members to use a custom format. Good for
returning an array of strings or different output saving an additional
loop after this. (like in https://github.com/yeoman/yeoman-generator-list/pull/23/files#diff-7e051b4df176cc4ddd6101faa1cfd585R22)
