### PR TITLE
Let `.count` take a non-existent keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ module.exports.count = function (keyword, cb) {
 			return;
 		}
 
-		cb(null, data[0].value);
+		cb(null, data[0] ?
+			data[0].value :
+			0
+		);
 	});
 };


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/npm-keyword/issues/4
