### PR TITLE
Update search endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function get(keyword, options) {
 }
 
 module.exports = (keyword, options) => {
-	options = options || {size: 250};
+	options = Object.assign({size: 250}, options);
+
 	return get(keyword, options).then(data => {
 		return data.objects.map(el => ({
 			name: el.package.name,
@@ -25,7 +26,8 @@ module.exports = (keyword, options) => {
 };
 
 module.exports.names = (keyword, options) => {
-	options = options || {size: 250};
+	options = Object.assign({size: 250}, options);
+
 	return get(keyword, options).then(data => data.objects.map(x => x.package.name));
 };
 

--- a/index.js
+++ b/index.js
@@ -2,35 +2,31 @@
 const got = require('got');
 const registryUrl = require('registry-url');
 
-function get(keyword, level) {
+function get(keyword, size) {
 	if (typeof keyword !== 'string') {
 		return Promise.reject(new TypeError('Keyword must be a string'));
 	}
 
 	keyword = encodeURIComponent(keyword);
 
-	const url = registryUrl() +
-		'-/_view/byKeyword?' +
-		'startkey=[%22' + keyword + '%22]' +
-		'&endkey=[%22' + keyword + '%22,%7B%7D]' +
-		'&group_level=' + level;
+	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${size}`;
 
-	return got(url, {json: true}).then(response => response.body.rows);
+	return got(url, {json: true}).then(response => response.body);
 }
 
 module.exports = keyword => {
-	return get(keyword, 3).then(data => {
-		return data.map(el => ({
-			name: el.key[1],
-			description: el.key[2]
+	return get(keyword, 250).then(data => {
+		return data.objects.map(el => ({
+			name: el.package.name,
+			description: el.package.description
 		}));
 	});
 };
 
 module.exports.names = keyword => {
-	return get(keyword, 2).then(data => data.map(x => x.key[1]));
+	return get(keyword, 250).then(data => data.objects.map(x => x.package.name));
 };
 
 module.exports.count = keyword => {
-	return get(keyword, 1).then(data => data[0] ? data[0].value : 0);
+	return get(keyword, 1).then(data => data.total);
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ function get(keyword, options) {
 		return Promise.reject(new TypeError('Keyword must be a string'));
 	}
 
+	if (options.size < 1 || options.size > 250) {
+		return Promise.reject(new TypeError('Size option must be between 1 and 250'));
+	}
+
 	keyword = encodeURIComponent(keyword);
 
 	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${options.size}`;
@@ -32,5 +36,5 @@ module.exports.names = (keyword, options) => {
 };
 
 module.exports.count = keyword => {
-	return get(keyword, {size: 0}).then(data => data.total);
+	return get(keyword, {size: 1}).then(data => data.total);
 };

--- a/index.js
+++ b/index.js
@@ -2,20 +2,21 @@
 const got = require('got');
 const registryUrl = require('registry-url');
 
-function get(keyword, size) {
+function get(keyword, options) {
 	if (typeof keyword !== 'string') {
 		return Promise.reject(new TypeError('Keyword must be a string'));
 	}
 
 	keyword = encodeURIComponent(keyword);
 
-	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${size}`;
+	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${options.size}`;
 
 	return got(url, {json: true}).then(response => response.body);
 }
 
-module.exports = keyword => {
-	return get(keyword, 250).then(data => {
+module.exports = (keyword, options) => {
+	options = options || {size: 250};
+	return get(keyword, options).then(data => {
 		return data.objects.map(el => ({
 			name: el.package.name,
 			description: el.package.description
@@ -23,10 +24,11 @@ module.exports = keyword => {
 	});
 };
 
-module.exports.names = keyword => {
-	return get(keyword, 250).then(data => data.objects.map(x => x.package.name));
+module.exports.names = (keyword, options) => {
+	options = options || {size: 250};
+	return get(keyword, options).then(data => data.objects.map(x => x.package.name));
 };
 
 module.exports.count = keyword => {
-	return get(keyword, 1).then(data => data.total);
+	return get(keyword, {size: 0}).then(data => data.total);
 };

--- a/readme.md
+++ b/readme.md
@@ -38,16 +38,53 @@ The list of packages will contain a maximum of 250 packages matching the keyword
 
 Returns a promise for a list of packages having the specified keyword in their package.json `keyword` property.
 
-The `options` parameter can be used to limit the amount of results via `npmKeyword('gulpplugin', {size: 10})`.
+#### keyword
+
+Type: `string`
+
+The search keyword.
+
+#### options
+
+Type: `object`
+
+##### size
+
+Type: `number`
+Default: `250`
+
+Limits the amount of results.
 
 ### npmKeyword.names(keyword, [options])
 
 Returns a promise for a list of package names. Use this if you don't need the description as it's faster.
 
+#### keyword
+
+Type: `string`
+
+The search keyword.
+
+#### options
+
+Type: `object`
+
+##### size
+
+Type: `number`
+Default: `250`
+
+Limits the amount of results.
+
 ### npmKeyword.count(keyword)
 
 Returns a promise for the count of packages.
 
+#### keyword
+
+Type: `string`
+
+The search keyword.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -29,16 +29,18 @@ const npmKeyword = require('npm-keyword');
 
 ## Caveat
 
-The list of packages will contain the first 250 packages matching the keyword. This limitation is caused by the [npm registry API](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search).
+The list of packages will contain a maximum of 250 packages matching the keyword. This limitation is caused by the [npm registry API](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search).
 
 
 ## API
 
-### npmKeyword(keyword)
+### npmKeyword(keyword, [options])
 
 Returns a promise for a list of packages having the specified keyword in their package.json `keyword` property.
 
-### npmKeyword.names(keyword)
+The `options` parameter can be used to limit the amount of results via `npmKeyword('gulpplugin', {size: 10})`.
+
+### npmKeyword.names(keyword, [options])
 
 Returns a promise for a list of package names. Use this if you don't need the description as it's faster.
 

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,13 @@ const npmKeyword = require('npm-keyword');
 	//=> ['gulp-autoprefixer', …]
 
 	console.log(await npmKeyword.count('gulpplugin'));
-	//=> 1930
+	//=> 3457
 })();
 ```
+
+## Caveat
+
+The list of packages will contain the first 250 packages matching the keyword. This limitation is caused by the [npm registry API](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search).
 
 
 ## API

--- a/test.js
+++ b/test.js
@@ -4,16 +4,29 @@ import m from '.';
 test('npmKeyword()', async t => {
 	const packages = await m('gulpplugin');
 
-	t.true(packages.length > 0);
+	t.true(packages.length === 250);
 	t.true(packages[0].name.length > 0);
 	t.true(packages[0].description.length > 0);
+});
+
+test('npmKeyword(10)', async t => {
+	const packages = await m('gulpplugin', {size: 10});
+
+	t.true(packages.length === 10);
 });
 
 test('npmKeyword.names()', async t => {
 	const packageNames = await m.names('gulpplugin');
 
+	t.true(packageNames.length === 250);
 	t.is(typeof packageNames[0], 'string');
 	t.true(packageNames[0].length > 0);
+});
+
+test('npmKeyword.names(10)', async t => {
+	const packageNames = await m.names('gulpplugin', {size: 10});
+
+	t.true(packageNames.length === 10);
 });
 
 test('npmKeyword.count()', async t => {

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import m from '.';
 test('npmKeyword()', async t => {
 	const packages = await m('gulpplugin');
 
-	t.true(packages.length === 250);
+	t.is(packages.length, 250);
 	t.true(packages[0].name.length > 0);
 	t.true(packages[0].description.length > 0);
 });
@@ -12,13 +12,13 @@ test('npmKeyword()', async t => {
 test('npmKeyword(10)', async t => {
 	const packages = await m('gulpplugin', {size: 10});
 
-	t.true(packages.length === 10);
+	t.is(packages.length, 10);
 });
 
 test('npmKeyword.names()', async t => {
 	const packageNames = await m.names('gulpplugin');
 
-	t.true(packageNames.length === 250);
+	t.is(packageNames.length, 250);
 	t.is(typeof packageNames[0], 'string');
 	t.true(packageNames[0].length > 0);
 });
@@ -26,7 +26,7 @@ test('npmKeyword.names()', async t => {
 test('npmKeyword.names(10)', async t => {
 	const packageNames = await m.names('gulpplugin', {size: 10});
 
-	t.true(packageNames.length === 10);
+	t.is(packageNames.length, 10);
 });
 
 test('npmKeyword.count()', async t => {

--- a/test.js
+++ b/test.js
@@ -9,10 +9,16 @@ test('npmKeyword()', async t => {
 	t.true(packages[0].description.length > 0);
 });
 
-test('npmKeyword(10)', async t => {
+test('npmKeyword() using the size option', async t => {
 	const packages = await m('gulpplugin', {size: 10});
 
 	t.is(packages.length, 10);
+});
+
+test('npmKeyword() using invalid options', async t => {
+	const packages = await m('gulpplugin', {foo: 'bar'});
+
+	t.true(packages.length === 250);
 });
 
 test('npmKeyword.names()', async t => {
@@ -23,10 +29,16 @@ test('npmKeyword.names()', async t => {
 	t.true(packageNames[0].length > 0);
 });
 
-test('npmKeyword.names(10)', async t => {
+test('npmKeyword.names() using the size option', async t => {
 	const packageNames = await m.names('gulpplugin', {size: 10});
 
 	t.is(packageNames.length, 10);
+});
+
+test('npmKeyword.names() using invalid options', async t => {
+	const packageNames = await m.names('gulpplugin', {foo: 'bar'});
+
+	t.true(packageNames.length === 250);
 });
 
 test('npmKeyword.count()', async t => {

--- a/test.js
+++ b/test.js
@@ -18,7 +18,19 @@ test('npmKeyword() using the size option', async t => {
 test('npmKeyword() using invalid options', async t => {
 	const packages = await m('gulpplugin', {foo: 'bar'});
 
-	t.true(packages.length === 250);
+	t.is(packages.length, 250);
+});
+
+test('npmKeyword() size < 1', async t => {
+	const error = await t.throws(m('gulpplugin', {size: 0}));
+
+	t.is(error.message, 'Size option must be between 1 and 250');
+});
+
+test('npmKeyword() size > 250', async t => {
+	const error = await t.throws(m('gulpplugin', {size: 255}));
+
+	t.is(error.message, 'Size option must be between 1 and 250');
 });
 
 test('npmKeyword.names()', async t => {
@@ -38,7 +50,7 @@ test('npmKeyword.names() using the size option', async t => {
 test('npmKeyword.names() using invalid options', async t => {
 	const packageNames = await m.names('gulpplugin', {foo: 'bar'});
 
-	t.true(packageNames.length === 250);
+	t.is(packageNames.length, 250);
 });
 
 test('npmKeyword.count()', async t => {


### PR DESCRIPTION
This will close #9.

I’ve used the npm API instead of the npms API since they both share the same limitations. See change in README. Reason: the »native« API _might_ be better maintained. Plus this makes sure this package keeps working with a private registry.

Let me know if you would like me to change this nevertheless.

## Question
Do you we should expose the `size` param to this modules API?

