### PR TITLE
support private npm registry with auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function getAuth() {
 	const conf = npmConf();
 	const auth = conf.get('_auth');
 	if (auth) {
-		return Buffer.from(auth, 'base64');
+		return Buffer.from(auth, 'base64').toString('ascii');
 	}
 
 	return auth;
@@ -58,6 +58,7 @@ module.exports.names = async (keyword, options) => {
 };
 
 module.exports.count = async keyword => {
-	const {total} = await get(keyword, {size: 1});
-	return total;
+	const result = await get(keyword, {size: 1});
+	require('fs').writeFile('test.txt', JSON.stringify(result));
+	return result.total;
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,17 @@
 'use strict';
 const got = require('got');
 const registryUrl = require('registry-url');
+const npmConf = require('npm-conf');
+
+function getAuth() {
+	const conf = npmConf();
+	const auth = conf.get('_auth');
+	if (auth) {
+		return Buffer.from(auth, 'base64');
+	}
+
+	return auth;
+}
 
 async function get(keyword, options) {
 	if (typeof keyword !== 'string' && !Array.isArray(keyword)) {
@@ -15,7 +26,7 @@ async function get(keyword, options) {
 
 	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${options.size}`;
 
-	const {body} = await got(url, {json: true});
+	const {body} = await got(url, {json: true, auth: getAuth()});
 	return body;
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	],
 	"dependencies": {
 		"got": "^9.6.0",
+		"npm-conf": "^1.1.3",
 		"registry-url": "^5.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
I've found that npm-keyword doesn't work if your .npmrc has a private npm registry configured that requires authentication. It always gets 401 responses.

I've tested the following with a .npmrc with a private registry and without. 

Without a private registry and _auth, the getAuth function returns undefined and it behaves as it always has. All 11 tests pass.

With a .npmrc, I ran npm test and all but the two count tests succeeded. I think this is more a problem with our private registry's API. Without the change, nothing passes.

Example of .npmrc
```
registry=https://mynpm.com/api/npm
email=somebody@corp.com
_auth=somebase64encodedauth=
always-auth=true
```

I hope you consider this pull request. Thanks!