### PR TITLE
Target Node.js 18, use `ky`, switch to named exports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
+          - 20
           - 18
-          - 16
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,57 +12,52 @@ export type PackageDescriptor = {
 	readonly description: string;
 };
 
-declare const npmKeyword: {
-	/**
-	Get a list of npm packages with certain keywords.
+/**
+Get a list of npm packages with certain keywords.
 
-	@param keyword - One or more keywords. Only matches packages that have *all* the given keywords.
-	@returns A list of packages having the specified keywords in their package.json `keyword` property.
+@param keyword - One or more keywords. Only matches packages that have *all* the given keywords.
+@returns A list of packages having the specified keywords in their package.json `keyword` property.
 
-	@example
-	```
-	import npmKeyword from 'npm-keyword';
+@example
+```
+import {npmKeyword} from 'npm-keyword';
 
-	console.log(await npmKeyword('gulpplugin'));
-	//=> [{name: 'gulp-autoprefixer', description: '…'}, …]
-	```
-	*/
-	(keyword: string | readonly string[], options?: Options): Promise<PackageDescriptor[]>;
+console.log(await npmKeyword('gulpplugin'));
+//=> [{name: 'gulp-autoprefixer', description: '…'}, …]
+```
+*/
+export function npmKeyword(keyword: string | readonly string[], options?: Options): Promise<PackageDescriptor[]>;
 
-	/**
-	Get a list of npm package names with certain keywords.
+/**
+Get a list of npm package names with certain keywords.
 
-	@param keyword - One or more keywords. Only matches packages that have *all* the given keywords. Example: `['string', 'camelcase']`.
-	@returns A list of package names. Use this if you don't need the description as it's faster.
+@param keyword - One or more keywords. Only matches packages that have *all* the given keywords. Example: `['string', 'camelcase']`.
+@returns A list of package names. Use this if you don't need the description as it's faster.
 
-	@example
-	```
-	import npmKeyword from 'npm-keyword';
+@example
+```
+import {npmKeywordNames} from 'npm-keyword';
 
-	console.log(await npmKeyword.names('gulpplugin'));
-	//=> ['gulp-autoprefixer', …]
-	```
-	*/
-	names(
-		keyword: string | readonly string[],
-		options?: Options
-	): Promise<string[]>;
+console.log(await npmKeywordNames('gulpplugin'));
+//=> ['gulp-autoprefixer', …]
+```
+*/
+export function npmKeywordNames(keyword: string | readonly string[], options?: Options): Promise<string[]>;
 
-	/**
-	Get the count of npm packages names with certain keywords.
+/**
+Get the count of npm packages names with certain keywords.
 
-	@param keyword - One or more keywords. Only matches packages that have *all* the given keywords. Example: `['string', 'camelcase']`.
-	@returns The count of packages.
+@param keyword - One or more keywords. Only matches packages that have *all* the given keywords. Example: `['string', 'camelcase']`.
+@returns The count of packages.
 
-	@example
-	```
-	import npmKeyword from 'npm-keyword';
+@example
+```
+import {npmKeywordCount} from 'npm-keyword';
 
-	console.log(await npmKeyword.count('gulpplugin'));
-	//=> 3457
-	```
-	*/
-	count(keyword: string | readonly string[]): Promise<number>;
-};
+console.log(await npmKeywordCount('gulpplugin'));
+//=> 3457
+```
+*/
+export function npmKeywordCount(keyword: string | readonly string[]): Promise<number>;
 
 export default npmKeyword;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import got from 'got';
+import ky from 'ky';
 import registryUrl from 'registry-url';
 
 const get = async (keyword, {size = 250} = {}) => {
@@ -14,7 +14,7 @@ const get = async (keyword, {size = 250} = {}) => {
 
 	const url = `${registryUrl()}-/v1/search?text=keywords:${keyword}&size=${size}`;
 
-	return got(url).json();
+	return ky(url).json();
 };
 
 export default async function npmKeyword(keyword, options) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const get = async (keyword, {size = 250} = {}) => {
 	return ky(url).json();
 };
 
-export default async function npmKeyword(keyword, options) {
+export async function npmKeyword(keyword, options) {
 	const {objects} = await get(keyword, options);
 
 	return objects.map(element => ({
@@ -26,12 +26,12 @@ export default async function npmKeyword(keyword, options) {
 	}));
 }
 
-npmKeyword.names = async (keyword, options) => {
+export async function npmKeywordNames(keyword, options) {
 	const {objects} = await get(keyword, options);
 	return objects.map(element => element.package.name);
-};
+}
 
-npmKeyword.count = async keyword => {
+export async function npmKeywordCount(keyword) {
 	const {total} = await get(keyword, {size: 1});
 	return total;
-};
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,13 @@
 import {expectType} from 'tsd';
-import npmKeyword, {type PackageDescriptor} from './index.js';
+import {
+	npmKeyword,
+	npmKeywordNames,
+	npmKeywordCount,
+	type PackageDescriptor,
+} from './index.js';
 
 expectType<Promise<PackageDescriptor[]>>(npmKeyword('gulpplugin'));
 expectType<Promise<PackageDescriptor[]>>(npmKeyword('gulpplugin', {size: 10}));
-expectType<Promise<string[]>>(npmKeyword.names('gulpplugin'));
-expectType<Promise<string[]>>(npmKeyword.names('gulpplugin', {size: 10}));
-expectType<Promise<number>>(npmKeyword.count('gulpplugin'));
+expectType<Promise<string[]>>(npmKeywordNames('gulpplugin'));
+expectType<Promise<string[]>>(npmKeywordNames('gulpplugin', {size: 10}));
+expectType<Promise<number>>(npmKeywordCount('gulpplugin'));

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
-	"types": "./index.d.ts",
+	"exports": {
+		"types": "./index.d.ts",
+		"default": "./index.js"
+	},
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -34,12 +36,12 @@
 		"search"
 	],
 	"dependencies": {
-		"got": "^12.1.0",
-		"registry-url": "^6.0.0"
+		"ky": "^1.2.1",
+		"registry-url": "^6.0.1"
 	},
 	"devDependencies": {
-		"ava": "^4.3.0",
-		"tsd": "^0.20.0",
-		"xo": "^0.56.0"
+		"ava": "^6.1.1",
+		"tsd": "^0.30.7",
+		"xo": "^0.57.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,16 @@ npm install npm-keyword
 ## Usage
 
 ```js
-import npmKeyword from 'npm-keyword';
+import {npmKeyword, npmKeywordNames, npmKeywordCount} from 'npm-keyword';
 
 console.log(await npmKeyword('gulpplugin'));
 //=> [{name: 'gulp-autoprefixer', description: '…'}, …]
+
+console.log(await npmKeywordNames('gulpplugin'));
+//=> ['gulp-autoprefixer', …]
+
+console.log(await npmKeywordCount('gulpplugin'));
+//=> 3457
 ```
 
 ## Caveat
@@ -45,7 +51,7 @@ Default: `250`
 
 Limits the amount of results.
 
-### npmKeyword.names(keywords, options?)
+### npmKeywordNames(keywords, options?)
 
 Returns a promise for a list of package names.
 
@@ -67,7 +73,7 @@ Default: `250`
 
 Limits the amount of results.
 
-### npmKeyword.count(keywords)
+### npmKeywordCount(keywords)
 
 Returns a promise for the count of packages.
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import npmKeyword from './index.js';
+import {npmKeyword, npmKeywordNames, npmKeywordCount} from './index.js';
 
 test('npmKeyword()', async t => {
 	const packages = await npmKeyword('gulpplugin');
@@ -39,46 +39,46 @@ test('npmKeyword() size > 250', async t => {
 	);
 });
 
-test('npmKeyword.names()', async t => {
-	const packageNames = await npmKeyword.names('gulpplugin');
+test('npmKeywordNames()', async t => {
+	const packageNames = await npmKeywordNames('gulpplugin');
 
 	t.is(packageNames.length, 250);
 	t.is(typeof packageNames[0], 'string');
 	t.true(packageNames[0].length > 0);
 });
 
-test('npmKeyword.names() using the size option', async t => {
-	const packageNames = await npmKeyword.names('gulpplugin', {size: 10});
+test('npmKeywordNames() using the size option', async t => {
+	const packageNames = await npmKeywordNames('gulpplugin', {size: 10});
 
 	t.is(packageNames.length, 10);
 });
 
-test('npmKeyword.names() using invalid options', async t => {
-	const packageNames = await npmKeyword.names('gulpplugin', {foo: 'bar'});
+test('npmKeywordNames() using invalid options', async t => {
+	const packageNames = await npmKeywordNames('gulpplugin', {foo: 'bar'});
 
 	t.is(packageNames.length, 250);
 });
 
-test('npmKeyword.count()', async t => {
-	const packagesWithValidKeyword = await npmKeyword.count('gulpplugin');
-	const packagesWithInvalidKeyword = await npmKeyword.count('äąâ');
+test('npmKeywordCount()', async t => {
+	const packagesWithValidKeyword = await npmKeywordCount('gulpplugin');
+	const packagesWithInvalidKeyword = await npmKeywordCount('äąâ');
 
 	t.true(packagesWithValidKeyword > 0);
 	t.is(typeof packagesWithValidKeyword, 'number');
 	t.is(packagesWithInvalidKeyword, 0);
 });
 
-test('npmKeyword.count() using an array of keywords', async t => {
-	const packagesWithOneKeyword = await npmKeyword.count('gulpplugin');
-	const packagesWithMultipleKeywords = await npmKeyword.count(['gulpplugin', 'sass', 'css']);
+test('npmKeywordCount() using an array of keywords', async t => {
+	const packagesWithOneKeyword = await npmKeywordCount('gulpplugin');
+	const packagesWithMultipleKeywords = await npmKeywordCount(['gulpplugin', 'sass', 'css']);
 
 	t.true(packagesWithMultipleKeywords > 0);
 	t.true(packagesWithMultipleKeywords < packagesWithOneKeyword);
 });
 
-test('npmKeyword.count() using wrong type for keywords parameter', async t => {
+test('npmKeywordCount() using wrong type for keywords parameter', async t => {
 	await t.throwsAsync(
-		npmKeyword.count({keyword: 'gulpplugin'}),
+		npmKeywordCount({keyword: 'gulpplugin'}),
 		{
 			message: /The keyword must be/,
 		},


### PR DESCRIPTION
Uses `ky` over `got`, and uses named exports:

```js
import {npmKeyword, npmKeywordNames, npmKeywordCount} from 'npm-keyword';

console.log(await npmKeyword('gulpplugin'));
//=> [{name: 'gulp-autoprefixer', description: '…'}, …]

console.log(await npmKeywordNames('gulpplugin'));
//=> ['gulp-autoprefixer', …]

console.log(await npmKeywordCount('gulpplugin'));
//=> 3457
```